### PR TITLE
Updated Date and DateTime field attributes to support nullable types.

### DIFF
--- a/Attributes/DateFieldAttribute.cs
+++ b/Attributes/DateFieldAttribute.cs
@@ -26,9 +26,23 @@ namespace X937.Attributes
         /// <param name="property">The information about the property to be set.</param>
         public override void DecodeField( BinaryReader reader, Record record, PropertyInfo property )
         {
-            var value = DateTime.ParseExact( reader.ReadEbcdicString( 8 ), "yyyyMMdd", null );
+            DateTime value;
 
-            property.SetValue( record, value );
+            if ( DateTime.TryParseExact( reader.ReadEbcdicString( 8 ), "yyyyMMdd", null, System.Globalization.DateTimeStyles.None, out value ) )
+            {
+                property.SetValue( record, value );
+            }
+            else
+            {
+                if ( property.PropertyType.IsGenericType && property.PropertyType.GetGenericTypeDefinition() == typeof( Nullable<> ) )
+                {
+                    property.SetValue( record, null );
+                }
+                else
+                {
+                    throw new Exception( "Null date found in data but property not nullable." );
+                }
+            }
         }
 
         /// <summary>
@@ -39,9 +53,11 @@ namespace X937.Attributes
         /// <param name="property">The information abou the property to be encoded.</param>
         public override void EncodeField( BinaryWriter writer, Record record, PropertyInfo property )
         {
-            DateTime value = ( DateTime ) property.GetValue( record );
+            var value = ( DateTime? ) property.GetValue( record );
 
-            writer.WriteEbcdicString( value.ToString( "yyyyMMdd" ) );
+            string valueStr = value.HasValue ? value.Value.ToString( "yyyyMMdd" ) : new string( ' ', Size );
+
+            writer.WriteEbcdicString( valueStr );
         }
     }
 }

--- a/Records/CashLetterControl.cs
+++ b/Records/CashLetterControl.cs
@@ -22,7 +22,7 @@ namespace X937.Records
         public string ECEInstitutionName { get; set; }
 
         [DateField( 7 )]
-        public DateTime SettlementDate { get; set; }
+        public DateTime? SettlementDate { get; set; }
 
         [TextField( 8, 15 )]
         protected string Reserved { get; set; }


### PR DESCRIPTION
If a nullable type (e.g. `DateTime?`) is found, then blank spaces will be inserted into the data stream on export.