### PR TITLE
Fixed record 52 Field 5 alignment to match Record 25 Field 8.

### DIFF
--- a/Records/ImageViewData.cs
+++ b/Records/ImageViewData.cs
@@ -15,7 +15,7 @@ namespace X937.Records
         [TextField( 4, 2 )]
         public string CycleNumber { get; set; }
 
-        [TextField( 5, 15 )]
+        [TextField( 5, 15, FieldJustification.Right )]
         public string ClientInstitutionItemSequenceNumber { get; set; }
 
         [TextField( 6, 16 )]


### PR DESCRIPTION
I don't know if the actual alignment is correct, different banks seem to want different alignment. ITS CALLED A STANDARD FOR A REASON! SOMEBODY FOLLOW IT! For the BotW component I am just manually padding the value to contain all 15 characters so there is no possibility of alignment issues (I hope).